### PR TITLE
Update contributor list and fix Snap Store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://www.gamecreation.org/
 ![Raincat screenshot](screenshot.png?raw=true "Raincat screenshot")
 
 ### Installation (Snap Store)
-Raincat is available in the Snap Store at: https://snapcraft.io/raincat-game
+Raincat is available in the Snap Store at: https://snapcraft.io/raincat
 
 It can be installed with:
 ```
@@ -91,4 +91,5 @@ Mikhail Pobolovets  - Programmer
 Sergei Trofimovich  - Programmer
 Raahul Kumar        - Programmer
 Alvaro F. García    - Programmer
+Alex Haydock        - Packaging (Snapcraft)
 ```


### PR DESCRIPTION
Hi,

Updating the "Other Contributors" list as suggested, and tweaking an error I noticed which pointed the Snap Store link to the wrong place.

This is assuming you have successfully obtained the `raincat` name on the store as suggested, and you will be adding the Snap to the store at the https://snapcraft.io/raincat link. That should be nice and easy to do now by just linking the package on Snapcraft to this Git repo and allowing their build infrastructure to do all the work.

Many thanks :smile: 
Alex